### PR TITLE
Add parens around typecasts so we can handle func options

### DIFF
--- a/template.go
+++ b/template.go
@@ -18,12 +18,8 @@ const codeTemplateText = `
 
 {{ if .imports }}
 import (
-{{- range .imports }}
-{{ if .Alias -}}
-  {{ .Alias }} "{{ .Path }}"
-{{ else }}
-"{{ .Path }}"
-{{ end }}
+{{ range .imports }}
+{{ if .Alias }}  {{ .Alias }} "{{ .Path }}"{{ else }}  "{{ .Path }}"{{ end -}}
 {{ end }}
 )
 {{ end }}
@@ -62,7 +58,7 @@ type {{ $.optionTypeName }} interface {
 type {{ $.optionPrefix }}{{ .PublicName | ToTitle }} {{ .Type }}
 
 func (o {{ $.optionPrefix }}{{ .PublicName | ToTitle }}) apply(c *{{ $.configTypeName }}) error {
-  c.{{ .Name }} = {{ .Type }}(o)
+  c.{{ .Name }} = ({{ .Type }})(o)
   return nil
 }
 {{ end }}

--- a/test/sample.go
+++ b/test/sample.go
@@ -20,6 +20,8 @@ type config struct {
 	myStringWithDefault   string `options:",default string"`
 	myStringWithoutOption string `options:"-"` // nolint:structcheck,unused // not expected to be used
 
+	myFunc              func() int
+
 	// types requiring imports
 	myURL url.URL
 	myDuration time.Duration

--- a/test/sample_test.go
+++ b/test/sample_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Generating options", func() {
 			OptionMyInt(123),
 			OptionMyFloat(4.56),
 			OptionMyString("my-string"),
+			OptionMyFunc(func() int { return 0 }),
 		)
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(cfg.myInt).Should(Equal(123))


### PR DESCRIPTION
Also avoid adding extra lines in imports