### PR TITLE
Add initial support for values with pointer receivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/go-options
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 test:
+	go clean -i .
 	go install .
 	go generate ./...
 	$(MAKE) lint

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ type Option struct {
 	PublicName   string
 	DefaultValue string
 	Type         string
-	HasPointerReceiver bool
+	IsPointer    bool
 }
 
 type Import struct {
@@ -167,12 +167,15 @@ func writeOptionsFile(types []string, packageName string, node ast.Node, fset *t
 				if publicName == "" {
 					publicName = n.Name
 				}
+				// TODO: inspect the actual type in case the type itself is a pointer receiver
+				_, isPointer := field.Type.(*ast.StarExpr)
+
 				options = append(options, Option{
 					Name:         n.Name,
 					PublicName:   publicName,
 					DefaultValue: defaultValue,
 					Type:         typeStr,
-					HasPointerReceiver: strings.HasPrefix(strings.TrimSpace(typeStr), "*"), // TODO: inspect the actual type
+					IsPointer:    isPointer,
 				})
 			}
 		}

--- a/template.go
+++ b/template.go
@@ -63,7 +63,7 @@ type {{ $.optionTypeName }} interface {
 }
 
 {{ range .options }}
-{{ if .HasPointerReceiver }}
+{{ if .IsPointer }}
 func {{ $.optionPrefix }}{{ .PublicName | ToTitle }}(o {{ .Type }}) {{ $applyOptionFuncType }} {
 	return func(c *{{ $.configTypeName }}) error {
     c.{{ .Name }} = ({{ .Type }})(o)

--- a/template.go
+++ b/template.go
@@ -28,6 +28,14 @@ import (
 const default{{ $.configTypeName | ToTitle }}{{ .Name | ToTitle }} {{ .Type }} = {{ .DefaultValue }}
 {{ end }}{{ end }}
 
+{{ $applyOptionFuncType := or $.applyOptionFuncType (printf "apply%sFunc" (ToTitle $.optionTypeName)) }} 
+
+type {{ $applyOptionFuncType }} func(c *{{ $.configTypeName }}) error
+
+func (f {{ $applyOptionFuncType }}) apply(c *{{ $.configTypeName }}) error {
+	return f(c)
+}
+
 {{ $applyFuncName := or $.applyFuncName (printf "apply%sOptions" (ToTitle $.configTypeName)) }} 
 
 {{ if $.createNewFunc}} 
@@ -55,11 +63,20 @@ type {{ $.optionTypeName }} interface {
 }
 
 {{ range .options }}
+{{ if .HasPointerReceiver }}
+func {{ $.optionPrefix }}{{ .PublicName | ToTitle }}(o {{ .Type }}) {{ $applyOptionFuncType }} {
+	return func(c *{{ $.configTypeName }}) error {
+    c.{{ .Name }} = ({{ .Type }})(o)
+    return nil
+	}
+}
+{{ else }}
 type {{ $.optionPrefix }}{{ .PublicName | ToTitle }} {{ .Type }}
 
 func (o {{ $.optionPrefix }}{{ .PublicName | ToTitle }}) apply(c *{{ $.configTypeName }}) error {
   c.{{ .Name }} = ({{ .Type }})(o)
   return nil
 }
+{{ end }}
 {{ end }}
 `

--- a/test/sample.go
+++ b/test/sample.go
@@ -22,6 +22,9 @@ type config struct {
 
 	myFunc              func() int
 
+	myPointerReceiver *int
+
+
 	// types requiring imports
 	myURL url.URL
 	myDuration time.Duration

--- a/test/sample.go
+++ b/test/sample.go
@@ -22,7 +22,7 @@ type config struct {
 
 	myFunc              func() int
 
-	myPointerReceiver *int
+	myIntPointer *int
 
 
 	// types requiring imports

--- a/test/sample_test.go
+++ b/test/sample_test.go
@@ -35,16 +35,19 @@ var _ = Describe("Generating options", func() {
 	cfg := config{}
 
 	It("generates options to set config value", func() {
+		myInt := 456
 		err := applyConfigOptions(&cfg,
 			OptionMyInt(123),
 			OptionMyFloat(4.56),
 			OptionMyString("my-string"),
+			OptionMyPointerReceiver(&myInt),
 			OptionMyFunc(func() int { return 0 }),
 		)
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(cfg.myInt).Should(Equal(123))
 		Ω(cfg.myFloat).Should(Equal(4.56))
 		Ω(cfg.myString).Should(Equal("my-string"))
+		Ω(cfg.myPointerReceiver).Should(Equal(&myInt))
 	})
 
 	It("generates an new function create a config", func() {

--- a/test/sample_test.go
+++ b/test/sample_test.go
@@ -40,14 +40,14 @@ var _ = Describe("Generating options", func() {
 			OptionMyInt(123),
 			OptionMyFloat(4.56),
 			OptionMyString("my-string"),
-			OptionMyPointerReceiver(&myInt),
+			OptionMyIntPointer(&myInt),
 			OptionMyFunc(func() int { return 0 }),
 		)
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(cfg.myInt).Should(Equal(123))
 		Ω(cfg.myFloat).Should(Equal(4.56))
 		Ω(cfg.myString).Should(Equal("my-string"))
-		Ω(cfg.myPointerReceiver).Should(Equal(&myInt))
+		Ω(cfg.myIntPointer).Should(Equal(&myInt))
 	})
 
 	It("generates an new function create a config", func() {


### PR DESCRIPTION
Support won't work for custom types that are pointers.  We eventually may want treat everything the way we are now treating pointer receivers in the future just for consistency.