### PR TITLE
Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.15.0
+    rev: v1.23.1
     hooks:
       - id: golangci-lint
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+    rev: v2.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml


### PR DESCRIPTION
Old versions weren't building in CI.  Just upgrading the hooks makes it pass again.